### PR TITLE
Update to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
   - name: Check out repository code
-    uses: actions/checkout@v3
+    uses: actions/checkout@v4
     with:
       ref: ${{github.event.pull_request.head.ref}}
       repository: ${{github.event.pull_request.head.repo.full_name}}


### PR DESCRIPTION
This seems like a sensible update as checkout@v3 still uses node16 which I think is long deprecated.

This might also help with an issue of mine where the action isn't running anymore in ppxlib: https://github.com/ocaml-ppx/ppxlib/pull/572.